### PR TITLE
Enable loading docker image from --dockerfile_path

### DIFF
--- a/perfzero/lib/setup.py
+++ b/perfzero/lib/setup.py
@@ -19,7 +19,9 @@ import argparse
 import json
 import logging
 import os
+import shutil
 import sys
+import tempfile
 import time
 
 import perfzero.device_utils as device_utils
@@ -27,7 +29,51 @@ import perfzero.perfzero_config as perfzero_config
 import perfzero.utils as utils
 
 
-def _create_docker_image(FLAGS, project_dir, workspace_dir, setup_execution_time):
+def _temporary_file_name(parent_dir, base_name):
+  """Returns a temp name of the form <parent-dir>/<random>/<base-name>."""
+  if not os.path.isdir(parent_dir):
+    os.makedirs(parent_dir)
+  temp_dir = tempfile.mkdtemp(dir=parent_dir)
+  return os.path.join(temp_dir, base_name)
+
+
+def _load_docker_image(FLAGS, workspace_dir, setup_execution_time):
+  """Runs docker load --input_image <FLAGS.dockerfile_path>.
+
+  Fetches FLAGS.dockerfile_path to workspace_dir/<temp-dir>/local_docker first.
+  Runs docker load --input <path-to-local-docker>.
+  Deletes workspace_dir/<temp-dir> after the docker image is loaded.
+
+  Args:
+    FLAGS: parser.parse_known_args object.
+    workspace_dir: String - The path to use for intermediate artifacts.
+    setup_execution_time: Map from string->double containing wall times for
+      different operations. This will have insertions describing the docker
+      setup time.
+  """
+  load_docker_start_time = time.time()
+  local_docker_image_path = _temporary_file_name(workspace_dir, 'local_docker')
+  utils.download_data([{'url': FLAGS.dockerfile_path,
+                        'local_path': local_docker_image_path,
+                        'decompress': False}])
+
+  setup_execution_time['fetch_docker'] = time.time() - load_docker_start_time
+
+  docker_load_cmd = 'docker load --input {}'.format(local_docker_image_path)
+  try:
+    utils.run_commands(
+        [docker_load_cmd,
+         'docker images'  # Print loaded image list.
+        ])
+    setup_execution_time['load_docker'] = time.time() - load_docker_start_time
+  finally:
+    logging.info('removing parent dir of local docker image copy %s',
+                 local_docker_image_path)
+    shutil.rmtree(os.path.dirname(local_docker_image_path))
+
+
+def _create_docker_image(FLAGS, project_dir, workspace_dir,
+                         setup_execution_time):
   """Creates a docker image.
 
   Args:
@@ -106,11 +152,20 @@ if __name__ == '__main__':
   project_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
   workspace_dir = os.path.join(project_dir, FLAGS.workspace)
 
+  activate_gcloud = False
+  if FLAGS.dockerfile_path.startswith('gs://'):
+    # We might end up doing gsutil fetch later, so need to call
+    # active_gcloud_service().
+    activate_gcloud = True
+  
+  if FLAGS.tensorflow_pip_spec and FLAGS.tensorflow_pip_spec.startswith('gs://'):
+    activate_gcloud = True
+
   # Download gcloud auth token. Remove this operation in the future when
   # docker in Kokoro can accesss the GCP metadata server
   start_time = time.time()
   utils.active_gcloud_service(FLAGS.gcloud_key_file_url,
-                              workspace_dir, download_only=True)
+                              workspace_dir, download_only=not activate_gcloud)
   setup_execution_time['download_token'] = time.time() - start_time
 
   # Set up the raid array.
@@ -120,8 +175,14 @@ if __name__ == '__main__':
   setup_execution_time['create_drive'] = time.time() - start_time
 
   if FLAGS.dockerfile_path:
-    _create_docker_image(FLAGS, project_dir, workspace_dir,
+    if FLAGS.dockerfile_path.endswith('.tar.gz'):
+      logging.info('Assuming given file %s is a docker image to load',
+                   FLAGS.dockerfile_path)
+      _load_docker_image(FLAGS, workspace_dir,
                          setup_execution_time)
+    else:
+      _create_docker_image(FLAGS, project_dir, workspace_dir,
+                           setup_execution_time)
 
   logging.info('Setup time in seconds by operation:\n %s',
                json.dumps(setup_execution_time, indent=2))


### PR DESCRIPTION
Currently --dockerfile_path points to a Dockerfile to save images.
If --dockerfile_path points to <file>.tar.gz, load the docker instead treating it as an image.
Also if --dockerfile_path is set to point to gs:// or tensorflow_pip_spec is set to gs:// we need to download and activate gcloud auth.